### PR TITLE
Fix: Removed incorrect parameter from Ownable constructor

### DIFF
--- a/src/mocks/SimpleNFT.sol
+++ b/src/mocks/SimpleNFT.sol
@@ -7,7 +7,7 @@ import { ERC721 } from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 contract SimpleNFT is ERC721, Ownable {
     uint256 public nextTokenId;
 
-    constructor(string memory name, string memory symbol) ERC721(name, symbol) Ownable(msg.sender) {}
+    constructor(string memory name, string memory symbol) ERC721(name, symbol) {}
 
     function mint(address to) public onlyOwner returns (uint256) {
         uint256 tokenId = nextTokenId++;


### PR DESCRIPTION
This PR fixes a critical issue in the `SimpleNFT.sol` contract where the `Ownable` constructor was incorrectly called with a parameter (`msg.sender`). 

### Issue:
- The `Ownable` constructor does not accept any parameters and automatically assigns the deployer's address as the owner.

### Fix:
- Removed `Ownable(msg.sender)` from the constructor in `SimpleNFT.sol`.
- The contract now uses the default behavior of the `Ownable` constructor.

### Testing:
- The contract compiles successfully without errors.
- Ownership is correctly assigned to the deployer during deployment.

This fix ensures that the `SimpleNFT` contract adheres to the standard usage of the `Ownable` module and eliminates compilation errors.


